### PR TITLE
Use ~/.config/xournalpp/plugins as suggested install dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ version 1.1.x and 1.2.x.
 To set the plugin up on Linux, run
 
 ```bash
-cd /usr/share/xournalpp/plugins
-sudo git clone https://github.com/raw-bacon/vi-xournalpp
+cd ~/.config/xournalpp/plugins
+git clone https://github.com/raw-bacon/vi-xournalpp
 ```
 
 In Xournal++, activate the plugin using the _Plugin Manager_


### PR DESCRIPTION
The `~/.config/xournalpp/plugins` dir may be more suitable than the provided path under `/usr`, for few reasons:
 - the user may not have the right write permissions nor the possibility to elevate privilages—handy also for config editing later on
 - easier config management along side other _dot-files_—no risk to forget backing up that dir again (yes, I've been there...)

Using the env var `$XDG_CONFIG_HOME` might be even better.

One thing: I've only tested this with the latest 1.2.1 release (no problem ofc), thus I don't exactly know from which version this is supported...