### PR TITLE
feat: vi-mode indicator

### DIFF
--- a/api/registry.lua
+++ b/api/registry.lua
@@ -366,4 +366,12 @@ return {
   getToolInfo = {
     { impl = wrapper.getToolInfo, deps = { 'getToolInfo' } },
   },
+
+  -- PLACEHOLDER
+  registerPlaceholder = {
+    { impl = wrapper.registerPlaceholder, deps = { 'registerPlaceholder' } },
+  },
+  setPlaceholderValue = {
+    { impl = wrapper.setPlaceholderValue, deps = { 'setPlaceholderValue' } },
+  },
 }

--- a/api/wrapper.lua
+++ b/api/wrapper.lua
@@ -325,4 +325,13 @@ wrapper.getToolInfo = function(tool)
   return app.getToolInfo(tool)
 end
 
+-- PLACEHOLDER
+wrapper.registerPlaceholder = function(name, description)
+  app.registerPlaceholder(name, description)
+end
+
+wrapper.setPlaceholderValue = function(placeholder, val)
+  app.setPlaceholderValue(placeholder, val)
+end
+
 return wrapper

--- a/keybindings.lua
+++ b/keybindings.lua
@@ -14,6 +14,18 @@ local ALL_MODES = {
   'resize',
 }
 
+local function changeMode(mode, stickyValue)
+  state.currentMode = mode
+  if stickyValue ~= nil then
+    state.sticky = stickyValue
+  end
+  local display = state.currentMode
+  if state.sticky then
+    display = display .. ' (sticky)'
+  end
+  api.setPlaceholderValue('vi-mode', display)
+end
+
 --------------------
 -- KEYBINDINGS:   --
 --------------------
@@ -88,8 +100,7 @@ local keybindings = {
     buttons = { 't' },
     modes = ALL_MODES,
     call = function()
-      state.currentMode = 'tool'
-      state.sticky = false
+      changeMode('tool', false)
     end,
   },
   color = {
@@ -97,7 +108,7 @@ local keybindings = {
     buttons = { 'c' },
     modes = { 'tool' },
     call = function()
-      state.currentMode = 'color'
+      changeMode('color')
     end,
   },
   stickyColor = {
@@ -105,8 +116,7 @@ local keybindings = {
     buttons = { '<Shift>c' },
     modes = { 'tool' },
     call = function()
-      state.currentMode = 'color'
-      state.sticky = true
+      changeMode('color', true)
     end,
   },
   shape = {
@@ -114,7 +124,7 @@ local keybindings = {
     buttons = { 'a' },
     modes = { 'tool' },
     call = function()
-      state.currentMode = 'shape'
+      changeMode('shape')
     end,
   },
   stickyShape = {
@@ -122,8 +132,7 @@ local keybindings = {
     buttons = { '<Shift>a' },
     modes = { 'tool' },
     call = function()
-      state.currentMode = 'shape'
-      state.sticky = true
+      changeMode('shape', true)
     end,
   },
   linestyle = {
@@ -131,7 +140,7 @@ local keybindings = {
     buttons = { 'q' },
     modes = { 'tool' },
     call = function()
-      state.currentMode = 'linestyle'
+      changeMode('linestyle')
     end,
   },
   stickyLinestyle = {
@@ -139,8 +148,7 @@ local keybindings = {
     buttons = { '<Shift>q' },
     modes = { 'tool' },
     call = function()
-      state.currentMode = 'linestyle'
-      state.sticky = true
+      changeMode('linestyle', true)
     end,
   },
   page = {
@@ -148,7 +156,7 @@ local keybindings = {
     buttons = { 'b', 'p' },
     modes = { 'tool' },
     call = function()
-      state.currentMode = 'page'
+      changeMode('page')
     end,
   },
   stickyPage = {
@@ -156,8 +164,7 @@ local keybindings = {
     buttons = { '<Shift>b', '<Shift>p' },
     modes = { 'tool' },
     call = function()
-      state.currentMode = 'page'
-      state.sticky = true
+      changeMode('page', true)
     end,
   },
   navigation = {
@@ -165,7 +172,7 @@ local keybindings = {
     buttons = { 'g' },
     modes = { 'tool' },
     call = function()
-      state.currentMode = 'navigation'
+      changeMode('navigation')
     end,
   },
   stickyNavigation = {
@@ -173,8 +180,7 @@ local keybindings = {
     buttons = { '<Shift>g' },
     modes = { 'tool' },
     call = function()
-      state.currentMode = 'navigation'
-      state.sticky = true
+      changeMode('navigation', true)
     end,
   },
   file = {
@@ -182,7 +188,7 @@ local keybindings = {
     buttons = { 'y' },
     modes = { 'tool' },
     call = function()
-      state.currentMode = 'file'
+      changeMode('file')
     end,
   },
   stickyFile = {
@@ -190,8 +196,7 @@ local keybindings = {
     buttons = { '<Shift>y' },
     modes = { 'tool' },
     call = function()
-      state.currentMode = 'file'
-      state.sticky = true
+      changeMode('file', true)
     end,
   },
   visual = {
@@ -199,7 +204,7 @@ local keybindings = {
     buttons = { 'v' },
     modes = { 'tool' },
     call = function()
-      state.currentMode = 'visual'
+      changeMode('visual')
     end,
   },
   stickyVisual = {
@@ -207,8 +212,7 @@ local keybindings = {
     buttons = { '<Shift>v' },
     modes = { 'tool' },
     call = function()
-      state.currentMode = 'visual'
-      state.sticky = true
+      changeMode('visual', true)
     end,
   },
   resize = {
@@ -216,7 +220,7 @@ local keybindings = {
     buttons = { '<Shift>F' },
     modes = { 'tool' },
     call = function()
-      state.currentMode = 'resize'
+      changeMode('resize')
     end,
   },
 
@@ -662,4 +666,5 @@ end
 return {
   bindings = keybindings,
   ALL_MODES = ALL_MODES,
+  changeMode = changeMode,
 }

--- a/main.lua
+++ b/main.lua
@@ -4,6 +4,7 @@ package.path = script_path .. '?.lua;' .. script_path .. '?/init.lua;' .. packag
 
 local utils = require('utils')
 local log = utils.log
+local api = require('api')
 
 local kb_module = require('keybindings')
 local keybindings = kb_module.bindings
@@ -62,6 +63,8 @@ end
 -- xournalpp require `initUi` as name
 ---@diagnostic disable-next-line: lowercase-global
 function initUi()
+  api.registerPlaceholder('vi-mode', 'Vi Mode Indicator')
+
   local index = 1
   local skipped = {}
 

--- a/modes.lua
+++ b/modes.lua
@@ -4,12 +4,13 @@ local state = require('state')
 
 local kb_module = require('keybindings')
 local keybindings = kb_module.bindings
+local changeMode = kb_module.changeMode
 
 local function handle(key)
   for _, binding in pairs(keybindings) do
     if binding.button_set[key] and binding.mode_set[state.currentMode] then
       if state.currentMode ~= 'tool' and not state.sticky then
-        state.currentMode = 'tool'
+        changeMode('tool')
       end
 
       if binding.call then


### PR DESCRIPTION
this PR is implements `registerPlaceholder`, `setPlaceholderValue` from Xournal's Lua API to establish mode indicator for vi-xournalapp, without breaking older versions of Xournal++

The tool gets added to the toolbar like any other tool

<img width="1920" height="1080" alt="Screenshot_20250819_233854" src="https://github.com/user-attachments/assets/e36b764e-bde2-4551-801b-25fd18e7073d" />


changes live by changing the mode

<img width="1920" height="1080" alt="Screenshot_20250819_233932" src="https://github.com/user-attachments/assets/7e10daf2-07f0-4682-a85d-8d124ce3cf83" />

closes #2 